### PR TITLE
Should we remove tag keys from aggregations and remove interval_size from Interval?

### DIFF
--- a/stats/census.proto
+++ b/stats/census.proto
@@ -187,8 +187,10 @@ message DistributionAggregation {
   repeated int64 bucket_counts = 5;
 
   // Tags associated with this DistributionAggregation. These will be filled
-  // in based on the View specification.
-  repeated Tag tags = 6;
+  // in based on the View specification. The tag value at index n corresponds
+  // to the tag key at index n in the associated ViewDescriptor. They must be
+  // printable ASCII.
+  repeated string tag_values = 6;
 }
 
 message DistributionAggregationDescriptor {
@@ -231,8 +233,10 @@ message IntervalAggregation {
   repeated Interval intervals = 1;
 
   // Tags associated with this IntervalAggregation. These will be filled in
-  // based on the View specification.
-  repeated Tag tags = 2;
+  // based on the View specification. The tag value at index n corresponds
+  // to the tag key at index n in the associated ViewDescriptor. They must be
+  // printable ASCII.
+  repeated string tag_values = 2;
 }
 
 // An IntervalAggreationDescriptor specifies time intervals for an
@@ -250,13 +254,6 @@ message IntervalAggregationDescriptor {
   // The size of each interval, as a time duration. Must have at least one
   // element. Each element must be positive.
   repeated Duration interval_sizes = 2;
-}
-
-// A Tag: key-value pair.
-// Both strings must be printable ASCII.
-message Tag {
-  string key = 1;
-  string value = 2;
 }
 
 // A ViewDescriptor specifies an AggregationDescriptor and a set of tag
@@ -279,7 +276,8 @@ message ViewDescriptor {
   }
 
   // Tag keys to match with a given measurement. If no keys are specified,
-  // then all stats are recorded. Keys must be unique.
+  // then all stats are recorded. Keys must be unique. They must be printable
+  // ASCII.
   repeated string tag_keys = 6;
 }
 

--- a/stats/census.proto
+++ b/stats/census.proto
@@ -220,15 +220,14 @@ message DistributionAggregationDescriptor {
 message IntervalAggregation {
   // Summary statistic over a single time interval.
   message Interval {
-    // The interval duration. Must be positive.
-    Duration interval_size = 1;
     // Approximate number of measurements recorded in this interval.
-    double count = 2;
+    double count = 1;
     // The cumulative sum of measurements in this interval.
-    double sum = 3;
+    double sum = 2;
   }
 
-  // Full set of intervals for this aggregation.
+  // Full set of intervals for this aggregation, corresponding to the
+  // interval_sizes in the associated IntervalAggregationDescriptor.
   repeated Interval intervals = 1;
 
   // Tags associated with this IntervalAggregation. These will be filled in
@@ -249,7 +248,7 @@ message IntervalAggregationDescriptor {
   int32 n_sub_intervals = 1;
 
   // The size of each interval, as a time duration. Must have at least one
-  // element.
+  // element. Each element must be positive.
   repeated Duration interval_sizes = 2;
 }
 


### PR DESCRIPTION
I was wondering if the fields are redundant with fields that are already in the descriptors.  If they are redundant, does it make sense to remove them? Here are my suggested changes.

/cc @dinooliva @a-veitch @acetechnologist